### PR TITLE
Update some modules to pass the tests on latest mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     { "name": "Nick Crohn", "email": "nick@meltmedia.com" }
   ],
   "dependencies": {
-    "simplecrawler": "0.0.x",
+    "simplecrawler": "0.3.x",
     "first": "0.0.x",
     "mime": "1.2.x",
     "optimist": "0.3.x",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node_hash": "0.2.x",
     "colors": ">= 0.6.0-1",
     "underscore": "1.4.x",
-    "prettyjson": "0.7.x"
+    "prettyjson": "0.9.x"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/crawler.js
+++ b/test/crawler.js
@@ -42,7 +42,7 @@ describe('crawler', function() {
 
     it('should difference 2 sites and return 1 page with no differences', function(done) {
       crawl.diff("http://127.0.0.1:8899", "http://127.0.0.1:8899", function(err, leftPages, rightPages, diffs) {
-        diffs.should.be.a('object').and.have.property('/');
+        diffs.should.be.type('object').and.have.property('/');
         diffs['/'].differences.should.be.false;
         done();
       });
@@ -52,7 +52,7 @@ describe('crawler', function() {
       crawl.diff(__dirname + "/assets/json/site1-left.json",
                  __dirname + "/assets/json/site1-right.json",
                  function(err, leftPages, rightPages, diffs) {
-        diffs.should.be.a('object').and.have.property('/');
+        diffs.should.be.type('object').and.have.property('/');
         diffs['/'].differences.should.be.false;
         done();
       });
@@ -62,7 +62,7 @@ describe('crawler', function() {
       crawl.diff(__dirname + "/assets/json/site2-left.json",
                  __dirname + "/assets/json/site2-right.json",
                  function(err, leftPages, rightPages, diffs) {
-        diffs.should.be.a('object').and.have.property('/');
+        diffs.should.be.type('object').and.have.property('/');
         diffs['/'].differences.should.be.true;
         done();
       });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --reporter spec
---ignore-leaks
 --require should
 --require colors
 --growl


### PR DESCRIPTION
## Summary
- Updated `prettyjson` for node v0.10.x support.
- Updated `simplejson` for passing tests on the latest mocha without `ignore-leaks` option.
